### PR TITLE
Enhancement/public privatekey helpers

### DIFF
--- a/bip32/extendedkey.go
+++ b/bip32/extendedkey.go
@@ -122,7 +122,6 @@ type ExtendedKey struct {
 // other applications should just use NewMaster, Child, or Neuter.
 func NewExtendedKey(version, key, chainCode, parentFP []byte, depth uint8,
 	childNum uint32, isPrivate bool) *ExtendedKey {
-
 	// NOTE: The pubKey field is intentionally left nil so it is only
 	// computed and memoized as required.
 	return &ExtendedKey{
@@ -374,37 +373,6 @@ func (k *ExtendedKey) ECPrivKey() (*bec.PrivateKey, error) {
 
 	privKey, _ := bec.PrivKeyFromBytes(bec.S256(), k.key)
 	return privKey, nil
-}
-
-// Address converts the extended key to a standard bitcoin pay-to-pubkey-hash
-// address for the passed network.
-func (k *ExtendedKey) Address(net *chaincfg.Params) string {
-	return k.addressFromPublicKeyHash(crypto.Hash160(k.pubKeyBytes()), net.Name == chaincfg.NetworkMain)
-}
-
-// addressFromPublicKeyHash is copied from the bt.bscript package to remove a small
-// dependency from bk -> bt. Adding this means bk has no dependency on bt.
-func (k *ExtendedKey) addressFromPublicKeyHash(hash []byte, mainnet bool) string {
-	// regtest := 111
-	// mainnet: 0
-
-	bb := make([]byte, 1)
-	if !mainnet {
-		bb[0] = 111
-	}
-
-	bb = append(bb, hash...)
-	b := make([]byte, 0, len(bb)+4)
-	b = append(b, bb[:]...)
-	ckSum := k.checksum(b)
-	b = append(b, ckSum[:]...)
-	return base58.Encode(b)
-}
-
-func (k *ExtendedKey) checksum(input []byte) (ckSum [4]byte) {
-	h := crypto.Sha256d(input)
-	copy(ckSum[:], h[:4])
-	return
 }
 
 // paddedAppend appends the src byte slice to dst, returning the new slice.

--- a/bip32/extendedkey_test.go
+++ b/bip32/extendedkey_test.go
@@ -16,6 +16,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/libsv/go-bk/chaincfg"
 )
 
@@ -648,8 +650,9 @@ func TestExtendedKeyAPI(t *testing.T) {
 			continue
 		}
 
-		addr := key.Address(&chaincfg.MainNet)
-		if addr != test.address {
+		addr, err := key.ToPublicKey()
+		assert.NoError(t, err)
+		if addr.Address != test.address {
 			t.Errorf("Address #%d (%s): mismatched address -- want "+
 				"%s, got %s", i, test.name, test.address,
 				addr)
@@ -821,8 +824,9 @@ func TestZero(t *testing.T) {
 		}
 
 		wantAddr := "1HT7xU2Ngenf7D4yocz2SAcnNLW7rK8d4E"
-		addr := key.Address(&chaincfg.MainNet)
-		if addr != wantAddr {
+		addr, err := key.ToPublicKeyWithNet(true)
+		assert.NoError(t, err)
+		if addr.Address != wantAddr {
 			t.Errorf("Address #%d (%s): mismatched address -- want "+
 				"%s, got %s", i, testName, wantAddr,
 				addr)
@@ -845,6 +849,7 @@ func TestZero(t *testing.T) {
 				i, test.name, err)
 			continue
 		}
+
 		neuteredKey, err := key.Neuter()
 		if err != nil {
 			t.Errorf("Neuter #%d (%s): unexpected error: %v", i,

--- a/bip32/extendedkey_test.go
+++ b/bip32/extendedkey_test.go
@@ -650,7 +650,7 @@ func TestExtendedKeyAPI(t *testing.T) {
 			continue
 		}
 
-		addr, err := key.ToPublicKey()
+		addr, err := key.ToAddress()
 		assert.NoError(t, err)
 		if addr.Address != test.address {
 			t.Errorf("Address #%d (%s): mismatched address -- want "+
@@ -824,7 +824,7 @@ func TestZero(t *testing.T) {
 		}
 
 		wantAddr := "1HT7xU2Ngenf7D4yocz2SAcnNLW7rK8d4E"
-		addr, err := key.ToPublicKeyWithNet(true)
+		addr, err := key.ToAddressWithNet(true)
 		assert.NoError(t, err)
 		if addr.Address != wantAddr {
 			t.Errorf("Address #%d (%s): mismatched address -- want "+

--- a/bip32/pk.go
+++ b/bip32/pk.go
@@ -1,0 +1,112 @@
+package bip32
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/libsv/go-bk/base58"
+	"github.com/libsv/go-bk/bec"
+	"github.com/libsv/go-bk/crypto"
+)
+
+var (
+	reNumericPlusTick = regexp.MustCompile(`^[0-9]+'{0,1}$`)
+)
+
+// PublicKey defines a single public key and public address.
+type PubKey struct {
+	PublicKey []byte
+	Address   string
+}
+
+// PublicKey will take a private key and derive the public key, returning the address string and bytes.
+// mainnet will determine if this is a main or testnet address and return the correct prefix accordingly.
+func PublicKey(privateKey *ExtendedKey, mainnet bool) (*PubKey, error) {
+	pub, err := privateKey.ECPubKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert key to public key %w", err)
+	}
+	k := pub.SerialiseCompressed()
+	publicKey, err := bec.ParsePubKey(k, bec.S256())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key %w", err)
+	}
+	hash := crypto.Hash160(publicKey.SerialiseCompressed())
+	bb := make([]byte, 1)
+	if !mainnet {
+		bb[0] = 111
+	}
+	bb = append(bb, hash...)
+	addr := base58EncodeMissingChecksum(bb)
+
+	size := len(addr)
+	if size < 26 || size > 34 {
+		return nil, errors.New("incorrect bitcoin address size")
+	}
+	return &PubKey{
+		PublicKey: k,
+		Address:   addr,
+	}, nil
+}
+
+// DeriveChildFromKey will return a private key derived from the root startingKey and located at the
+// derivationPath.
+// Child keys must be ints or hardened keys followed by '.
+// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+func DeriveChildFromKey(startingKey *ExtendedKey, derivationPath string) (*ExtendedKey, error) {
+	if derivationPath == "" {
+		return startingKey, nil
+	}
+	children := strings.Split(derivationPath, "/")
+	for _, child := range children {
+		if !isValidSegment(child) {
+			return nil, fmt.Errorf("invalid childpath segment %s", child)
+		}
+		childInt, err := childInt(child)
+		if err != nil {
+			return nil, err
+		}
+		startingKey, err = startingKey.Child(childInt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to derive child from key %w", err)
+		}
+	}
+	return startingKey, nil
+}
+
+func isValidSegment(child string) bool {
+	return reNumericPlusTick.MatchString(child)
+}
+
+func childInt(child string) (uint32, error) {
+	var suffix uint32
+	if strings.HasSuffix(child, "'") {
+		child = strings.TrimRight(child, "'")
+		suffix = 2147483648 // 2^32
+	}
+	t, err := strconv.Atoi(child)
+	if err != nil {
+		return 0, errors.New("child key is not an int")
+	}
+
+	return uint32(t) + suffix, nil
+}
+
+// base58EncodeMissingChecksum appends a checksum to a byte sequence
+// then encodes into base58 encoding.
+func base58EncodeMissingChecksum(input []byte) string {
+	b := make([]byte, 0, len(input)+4)
+	b = append(b, input[:]...)
+	cksum := checksum(b)
+	b = append(b, cksum[:]...)
+	return base58.Encode(b)
+}
+
+func checksum(input []byte) (cksum [4]byte) {
+	h := crypto.Sha256d(input)
+	copy(cksum[:], h[:4])
+	return
+}

--- a/bip32/pk.go
+++ b/bip32/pk.go
@@ -23,21 +23,21 @@ type PublicKey struct {
 	Address   string
 }
 
-// ToPublicKey will return the public key for the current extendedkey.
+// ToAddress will return the publicKey bytes for the current extendedkey as well as the address.
 // An appropriate mainnet or testnet address is determined by the ExtendedKey settings.
 //
-// If you are using a Zeroed ExtendedKey, use the ToPublicKeyWithNet method.
-func (k *ExtendedKey) ToPublicKey() (*PublicKey, error) {
-	return k.ToPublicKeyWithNet(k.IsForNet(&chaincfg.MainNet))
+// If you are using a Zeroed ExtendedKey, use the ToAddressWithNet method.
+func (k *ExtendedKey) ToAddress() (*PublicKey, error) {
+	return k.ToAddressWithNet(k.IsForNet(&chaincfg.MainNet))
 }
 
-// ToPublicKeyWithNet will return the public key for the current extendedkey.
-// This takes a mainnet param that if true will return a mainnet address, otherwise
+// ToAddressWithNet will return the publicKey bytes for the current extendedkey as well as the address.
+// This takes a mainnet param that if true will return a mainnet address (prefixed with 1), otherwise
 // a testnet address is returned.
 //
 // This method should only be used if you are dealing with a Zeroed ExtendedKey as it
-// cannot determine the network to use. Instead for most instances use ToPublicKey.
-func (k *ExtendedKey) ToPublicKeyWithNet(mainnet bool) (*PublicKey, error) {
+// cannot determine the network to use. Instead for most instances use ToAddress.
+func (k *ExtendedKey) ToAddressWithNet(mainnet bool) (*PublicKey, error) {
 	var pubKeyBytes []byte
 	if k.key == nil { // can be nil if this is a Zeroed ExtendedKey.
 		pubKeyBytes = k.pubKeyBytes()

--- a/bip32/pk_test.go
+++ b/bip32/pk_test.go
@@ -44,7 +44,7 @@ func TestPublicKey_DerivationPath(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			key, err := DeriveChildFromKey(rootKey, test.derivationPath)
+			key, err := rootKey.DeriveChildFromKey(test.derivationPath)
 			if test.err != nil {
 				assert.Nil(t, key)
 				assert.Error(t, err)
@@ -53,7 +53,7 @@ func TestPublicKey_DerivationPath(t *testing.T) {
 			}
 			assert.NotNil(t, key)
 			assert.NoError(t, err)
-			addr, err := PublicKey(key, false)
+			addr, err := key.ToPublicKey()
 			assert.NoError(t, err)
 			assert.Equal(t, test.expAddress, addr.Address)
 		})

--- a/bip32/pk_test.go
+++ b/bip32/pk_test.go
@@ -1,0 +1,126 @@
+package bip32
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// test addresses generated with https://bip32jp.github.io/english/
+func TestPublicKey_DerivationPath(t *testing.T) {
+	t.Parallel()
+	rootKey, err := NewKeyFromString("tprv8ZgxMBicQKsPcv8v71iiXGDnZ4p6hMc9qiHNdE6p8B79eFrTXVXv35vek8t44ENCbuczHU6co5PqwuAB9YLaDtXuZQrrwacq32BcU7C1TrC")
+	if err != nil {
+		t.Error(err)
+	}
+	tests := map[string]struct {
+		derivationPath string
+		expAddress     string
+		err            error
+	}{
+		"hardened nested path should generate correct address": {
+			derivationPath: "0'/0'/3'",
+			expAddress:     "mpdFaJf2cAHNfoxKU63o4QXx6NDbzR6E7d",
+		}, "hardened root path should generate correct address": {
+			derivationPath: "0'",
+			expAddress:     "moayMJYrSjfjuiLYxKhhDRUVqDEQWwXzpV",
+		}, "standard root path should generate correct address": {
+			derivationPath: "0",
+			expAddress:     "n2U89ELbUhJWucd9679coQ4W82H4Pme7oX",
+		}, "mixed path should generate correct address": {
+			derivationPath: "0/1'/2/0'",
+			expAddress:     "mkcX3WP4TCLiMU6JXttPnjUJTtjdVsdxBT",
+		}, "standard nested path should generate correct address": {
+			derivationPath: "0/1/2/5",
+			expAddress:     "mjGdCkFd57WJJVzTwFpTRf25XhUDRP3xca",
+		}, "invalid derivation path, only letter, should error": {
+			derivationPath: "T",
+			err:            errors.New("invalid childpath segment T"),
+		}, "invalid derivation path, mix of letters and numbers, should error": {
+			derivationPath: "0/1/f/4/e",
+			err:            errors.New("invalid childpath segment f"),
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			key, err := DeriveChildFromKey(rootKey, test.derivationPath)
+			if test.err != nil {
+				assert.Nil(t, key)
+				assert.Error(t, err)
+				assert.EqualError(t, err, test.err.Error())
+				return
+			}
+			assert.NotNil(t, key)
+			assert.NoError(t, err)
+			addr, err := PublicKey(key, false)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expAddress, addr.Address)
+		})
+	}
+}
+
+func TestPrivatekey_getChildInt(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		alias string
+		exp   uint32
+		err   error
+	}{
+		"child with '0' should return int": {
+			alias: "0",
+			exp:   0,
+			err:   nil,
+		}, "child with '1' should return int": {
+			alias: "1",
+			exp:   1,
+			err:   nil,
+		}, "child with hd key '1'' should return hd": {
+			alias: "1'",
+			exp:   2147483649,
+			err:   nil,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			r, err := childInt(test.alias)
+			if test.err == nil {
+				assert.NoError(t, err)
+				assert.Equal(t, test.exp, r)
+				return
+			}
+			assert.Empty(t, r)
+			assert.Error(t, err)
+			assert.Equal(t, test.err, err)
+		})
+	}
+}
+
+func TestPrivatekey_isValidSegment(t *testing.T) {
+	tests := map[string]struct {
+		segment string
+		exp     bool
+	}{
+		"empty should return invalid": {
+			segment: "",
+			exp:     false,
+		}, "single digit should return valid": {
+			segment: "0",
+			exp:     true,
+		}, "single digit with suffix should return valid": {
+			segment: "0'",
+			exp:     true,
+		}, "large number should return valid": {
+			segment: "1234567",
+			exp:     true,
+		}, "number with unknown char should return invalid": {
+			segment: "1234567/",
+			exp:     false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.exp, isValidSegment(test.segment))
+		})
+	}
+}

--- a/bip32/pk_test.go
+++ b/bip32/pk_test.go
@@ -53,7 +53,7 @@ func TestPublicKey_DerivationPath(t *testing.T) {
 			}
 			assert.NotNil(t, key)
 			assert.NoError(t, err)
-			addr, err := key.ToPublicKey()
+			addr, err := key.ToAddress()
 			assert.NoError(t, err)
 			assert.Equal(t, test.expAddress, addr.Address)
 		})


### PR DESCRIPTION
Added new ToPublicKey & ToPublicKeyWithNet methods to convert an Extended key to an address string.

Also added DeriveChildFromKey method to generate a new ExtendedKey from an existing key using a specified derivationPath.

Removed old Address method and added more tests to cover new methods. 