### PR TITLE
Derive path from seed

### DIFF
--- a/bip32/derivationpaths.go
+++ b/bip32/derivationpaths.go
@@ -1,0 +1,45 @@
+package bip32
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// DerivePath given a seed will generate a hardened BIP32 path 3 layers deep.
+//
+// This is achieved by the following process:
+// We split the seed bits into 3 sections: (b63-b32|b32-b1|b1-b0)
+// Each section is then added onto 2^31 and concatenated together which will give us the final path.
+func DerivePath(seed uint64) string {
+	path := fmt.Sprintf("%d/", seed>>32|1<<31)
+	path += fmt.Sprintf("%d/", ((seed<<32)>>34)|1<<31)
+	path += fmt.Sprintf("%d", (seed&3)|1<<31)
+	return path
+}
+
+// DeriveSeed when given a derivation path of format 0/0/0 will return the seed used to generate
+// the path.
+func DeriveSeed(path string) (uint64, error) {
+	ss := strings.Split(path, "/")
+	if len(ss) != 3 {
+		return 0, errors.New("path must have 3 levels ie 0/0/0")
+	}
+	d1, err := strconv.ParseUint(ss[0], 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	seed := (d1 - 1<<31) << 32
+	d2, err := strconv.ParseUint(ss[1], 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	seed += (d2 - (1 << 31)) << 2
+	d3, err := strconv.ParseUint(ss[2], 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	seed += d3 - (1 << 31)
+	return seed, nil
+}

--- a/bip32/derivationpaths.go
+++ b/bip32/derivationpaths.go
@@ -7,21 +7,22 @@ import (
 	"strings"
 )
 
-// DerivePath given a seed will generate a hardened BIP32 path 3 layers deep.
+// DerivePath given an uint64 number will generate a hardened BIP32 path 3 layers deep.
 //
 // This is achieved by the following process:
 // We split the seed bits into 3 sections: (b63-b32|b32-b1|b1-b0)
 // Each section is then added onto 2^31 and concatenated together which will give us the final path.
-func DerivePath(seed uint64) string {
-	path := fmt.Sprintf("%d/", seed>>32|1<<31)
-	path += fmt.Sprintf("%d/", ((seed<<32)>>34)|1<<31)
-	path += fmt.Sprintf("%d", (seed&3)|1<<31)
+func DerivePath(i uint64) string {
+	path := fmt.Sprintf("%d/", i>>32|1<<31)
+	path += fmt.Sprintf("%d/", ((i<<32)>>34)|1<<31)
+	path += fmt.Sprintf("%d", (i&3)|1<<31)
 	return path
 }
 
-// DeriveSeed when given a derivation path of format 0/0/0 will return the seed used to generate
+// DeriveNumber when given a derivation path of format 0/0/0 will
+// reverse the DerivePath function and return the number used to generate
 // the path.
-func DeriveSeed(path string) (uint64, error) {
+func DeriveNumber(path string) (uint64, error) {
 	ss := strings.Split(path, "/")
 	if len(ss) != 3 {
 		return 0, errors.New("path must have 3 levels ie 0/0/0")

--- a/bip32/derivationpaths_test.go
+++ b/bip32/derivationpaths_test.go
@@ -1,0 +1,103 @@
+package bip32
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_DerivePathAndDeriveSeed(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		counter      uint64
+		startingPath string
+		exp          string
+	}{
+		"successful run should return no errors": {
+			counter:      0,
+			startingPath: "",
+			exp:          "2147483648/2147483648/2147483648",
+		}, "172732732 counter with 0 path": {
+			counter:      172732732,
+			startingPath: "",
+			exp:          "2147483648/2190666831/2147483648",
+		}, "max int should return max int with root path": {
+			counter:      math.MaxInt32 + 172732732,
+			startingPath: "",
+			exp:          "2147483648/2727537742/2147483651",
+		}, "max int * 2 should return 1 with root path": {
+			counter:      (math.MaxInt32 * 10000) + 172732732,
+			startingPath: "",
+			exp:          "2147488648/2190664331/2147483648",
+		}, "max int squared should return 0/0 path": {
+			counter:      (math.MaxInt32 * math.MaxInt32) + 172732732,
+			startingPath: "",
+			exp:          "3221225471/2190666831/2147483649",
+		}, "max int squared + 100 should return correct path": {
+			counter:      (math.MaxInt32*math.MaxInt32 + (math.MaxInt32 * 100)) + 172732732,
+			startingPath: "",
+			exp:          "3221225521/2190666806/2147483649",
+		}, "max int squared plus two int32 should return correct path": {
+			counter:      ((math.MaxInt32 * math.MaxInt32 * 1) + (math.MaxInt32 * 2)) + 172732732,
+			startingPath: "",
+			exp:          "3221225472/2190666830/2147483651",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.exp, DerivePath(test.counter))
+			// assert the path can be converted correctly back to the seed.
+			c, _ := DeriveSeed(test.exp)
+			assert.Equal(t, test.counter, c)
+		})
+	}
+}
+
+func TestDeriveSeed(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		path string
+		err  error
+	}{
+		"missing path should error": {
+			err: errors.New("path must have 3 levels ie 0/0/0"),
+		},
+		"path too long should error": {
+			path: "0/0/0/0",
+			err:  errors.New("path must have 3 levels ie 0/0/0"),
+		},
+		"path too short should error": {
+			path: "0/0",
+			err:  errors.New("path must have 3 levels ie 0/0/0"),
+		},
+		"path length 3 should not error": {
+			path: "0/0/0",
+			err:  nil,
+		},
+		"path overflow uint32 should error": {
+			path: "4294967296/0/0",
+			err: &strconv.NumError{
+				Func: "ParseUint",
+				Num:  "4294967296",
+				Err:  errors.New("value out of range"),
+			},
+		},
+		"path less than min uint32 should error": {
+			path: "-1/0/0",
+			err: &strconv.NumError{
+				Func: "ParseUint",
+				Num:  "-1",
+				Err:  errors.New("invalid syntax"),
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := DeriveSeed(test.path)
+			assert.Equal(t, test.err, err)
+		})
+	}
+}

--- a/bip32/derivationpaths_test.go
+++ b/bip32/derivationpaths_test.go
@@ -50,7 +50,7 @@ func Test_DerivePathAndDeriveSeed(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, test.exp, DerivePath(test.counter))
 			// assert the path can be converted correctly back to the seed.
-			c, _ := DeriveSeed(test.exp)
+			c, _ := DeriveNumber(test.exp)
 			assert.Equal(t, test.counter, c)
 		})
 	}
@@ -96,7 +96,7 @@ func TestDeriveSeed(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, err := DeriveSeed(test.path)
+			_, err := DeriveNumber(test.path)
 			assert.Equal(t, test.err, err)
 		})
 	}


### PR DESCRIPTION
This PR adds new derivePath and deriveSeed methods, used to create deterministic bip32 paths.

This can be used to store an atomic counter in a persistent store and simply increment the counter when you need a new private key created. Pass the seed to DerivePath and will return a deterministic path by splitting the bits into 3 and joining them. This can then be reversed by calling DerivateSeed wherein you provide a path and the seed used is returned.