### PR TITLE
Extended Key Derivation helpers

### DIFF
--- a/bip32/derivationpaths.go
+++ b/bip32/derivationpaths.go
@@ -3,8 +3,13 @@ package bip32
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
+)
+
+var (
+	numericPlusTick = regexp.MustCompile(`^[0-9]+'{0,1}$`)
 )
 
 // DerivePath given an uint64 number will generate a hardened BIP32 path 3 layers deep.
@@ -43,4 +48,56 @@ func DeriveNumber(path string) (uint64, error) {
 	}
 	seed += d3 - (1 << 31)
 	return seed, nil
+}
+
+// DeriveKeyFromPath will generate a new extended key derived from the key k using the
+// bip32 path provided, ie "1234/0/123"
+func (k *ExtendedKey) DeriveChildFromPath(path string) (*ExtendedKey, error) {
+	key := k
+	if path != "" {
+		children := strings.Split(path, "/")
+		for _, child := range children {
+			if !numericPlusTick.MatchString(child) {
+				return nil, fmt.Errorf("invalid path: %q", path)
+			}
+			childInt, err := getChildInt(child)
+			if err != nil {
+				return nil, fmt.Errorf("derive key failed %w", err)
+			}
+			var childErr error
+			key, childErr = key.Child(childInt)
+			if childErr != nil {
+				return nil, fmt.Errorf("derive key failed %w", childErr)
+			}
+		}
+	}
+	return key, nil
+}
+
+// DerivePublicKeyFromPath will generate a new extended key derived from the key k using the
+// bip32 path provided, ie "1234/0/123". It will then transform to an bec.PublicKey before
+// serialising the bytes and returning.
+func (k *ExtendedKey) DerivePublicKeyFromPath(path string) ([]byte, error) {
+	key, err := k.DeriveChildFromPath(path)
+	if err != nil {
+		return nil, err
+	}
+	pubKey, err := key.ECPubKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate public key %w", err)
+	}
+	return pubKey.SerialiseCompressed(), nil
+}
+
+func getChildInt(child string) (uint32, error) {
+	var suffix uint32
+	if strings.HasSuffix(child, "'") {
+		child = strings.TrimRight(child, "'")
+		suffix = 2147483648 // 2^32
+	}
+	t, err := strconv.ParseUint(child, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get child int %w", err)
+	}
+	return uint32(t) + suffix, nil
 }

--- a/bip32/derivationpaths.go
+++ b/bip32/derivationpaths.go
@@ -50,11 +50,11 @@ func DeriveNumber(path string) (uint64, error) {
 	return seed, nil
 }
 
-// DeriveKeyFromPath will generate a new extended key derived from the key k using the
+// DeriveChildFromPath will generate a new extended key derived from the key k using the
 // bip32 path provided, ie "1234/0/123"
 // Child keys must be ints or hardened keys followed by '.
 // https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
-func (k *ExtendedKey) DeriveKeyFromPath(derivationPath string) (*ExtendedKey, error) {
+func (k *ExtendedKey) DeriveChildFromPath(derivationPath string) (*ExtendedKey, error) {
 	if derivationPath == "" {
 		return k, nil
 	}
@@ -80,7 +80,7 @@ func (k *ExtendedKey) DeriveKeyFromPath(derivationPath string) (*ExtendedKey, er
 // bip32 path provided, ie "1234/0/123". It will then transform to an bec.PublicKey before
 // serialising the bytes and returning.
 func (k *ExtendedKey) DerivePublicKeyFromPath(derivationPath string) ([]byte, error) {
-	key, err := k.DeriveKeyFromPath(derivationPath)
+	key, err := k.DeriveChildFromPath(derivationPath)
 	if err != nil {
 		return nil, err
 	}

--- a/bip32/derivationpaths_test.go
+++ b/bip32/derivationpaths_test.go
@@ -101,3 +101,76 @@ func TestDeriveSeed(t *testing.T) {
 		})
 	}
 }
+
+func Test_DeriveChildFromPath(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		key     *ExtendedKey
+		path    string
+		expPriv string
+		expPub  string
+		err     error
+	}{
+		"successful run, 1 level child, should return no errors": {
+			key: func() *ExtendedKey {
+				k, err := NewKeyFromString("xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi")
+				assert.NoError(t, err)
+				return k
+			}(),
+			path:    "0/1",
+			expPriv: "xprv9ww7sMFLzJMzy7bV1qs7nGBxgKYrgcm3HcJvGb4yvNhT9vxXC7eX7WVULzCfxucFEn2TsVvJw25hH9d4mchywguGQCZvRgsiRaTY1HCqN8G",
+			expPub:  "xpub6AvUGrnEpfvJBbfx7sQ89Q8hEMPM65UteqEX4yUbUiES2jHfjexmfJoxCGSwFMZiPBaKQT1RiKWrKfuDV4vpgVs4Xn8PpPTR2i79rwHd4Zr",
+			err:     nil,
+		}, "successful run, 2 level child, should return no errors": {
+			key: func() *ExtendedKey {
+				k, err := NewKeyFromString("xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi")
+				assert.NoError(t, err)
+				return k
+			}(),
+			path:    "0/1/100000",
+			expPriv: "xprv9xrdP7iD2MKJthXr1NiyGJ5KqmD2sLbYYFi49AMq9bXrKJGKBnjx5ivSzXRfLhXxzQNsqCi51oUjniwGemvfAZpzpAGohpzFkat42ohU5bR",
+			expPub:  "xpub6BqyndF6risc7BcK7QFydS24Po3XGoKPuUdewYmShw4qC6bTjL4CdXEvqow6yhsfAtvU8e6kHPNFM2LzeWwKQoJm6hrYttTcxVQrk42WRE3",
+			err:     nil,
+		}, "successful run, 10 level child, should return no errors": {
+			key: func() *ExtendedKey {
+				k, err := NewKeyFromString("xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi")
+				assert.NoError(t, err)
+				return k
+			}(),
+			path:    "0/1/1/1/1/1/1/1/1/2147483647",
+			expPriv: "xprvAD89K3nZjaG8NqELN8Ce2ATWTcRADLH6JTbrXoVJT6eBRbMwbG7J75v3ym4tGC7X3Mih5krQF77pGi6GNdvxfNcr6WqYacHCSa6uzotoAx2",
+			expPub:  "xpub6S7ViZKTZwpRbKJoU9jePJQF1eFecnzwfgXTLBtv1SBAJPh68oRYetEXq1RvGzsYnTzeikfdM5UM3WDrSZxuBrJi5nLpGxsuSE6cDE8pB2o",
+			err:     nil,
+		}, "successful run, 1 level, hardened": {
+			key: func() *ExtendedKey {
+				k, err := NewKeyFromString("xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi")
+				assert.NoError(t, err)
+				return k
+			}(),
+			path:    "0/1'",
+			expPriv: "xprv9ww7sMFVKxty8iXvY7Yn2NyvHZ2CgEoAYXmvf2a4XvkhzBUBmYmaMWyjyAhSxgyKK4zYzbJT6hT4JeGW5fFcNaYsBsBR9a8TxVX1LJQiZ1P",
+			expPub:  "xpub6AvUGrnPALTGMCcPe95nPWveqarh5hX1ukhXTQyg6GHgryoLK65puKJDpTcMBKJKdtXQYVwbK3zMgydcTcf5qpLpJcULu9hKUxx5rzgYhrk",
+			err:     nil,
+		}, "successful run, 3 level, hardened": {
+			key: func() *ExtendedKey {
+				k, err := NewKeyFromString("xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi")
+				assert.NoError(t, err)
+				return k
+			}(),
+			path:    "10/1'/1000'/15'",
+			expPriv: "xprvA1bKm9LnkQbMvUW6kwKDLFapT9V9vTeh9D9VnVSJhRf8KmqQTc9W5YboNYcUUkZLreNq1NmeuPpw8x86C87gGyxyV6jNBV4kztFrPdSWz2t",
+			expPub:  "xpub6EagAesgan9f8xaZrxrDhPXZ1BKeKvNYWS56asqvFmC7CaAZ19TkdLvHDrzubSMiC6tAqTMcumVFkgT2duhZncV3KieshEDHNc4jPWkRMGD",
+			err:     nil,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			k, err := test.key.DeriveChildFromPath(test.path)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expPriv, k.String())
+			pubKey, err := k.Neuter()
+			assert.NoError(t, err)
+			assert.Equal(t, test.expPub, pubKey.String())
+		})
+	}
+}

--- a/bip32/derivationpaths_test.go
+++ b/bip32/derivationpaths_test.go
@@ -165,7 +165,7 @@ func Test_DeriveChildFromPath(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			k, err := test.key.DeriveKeyFromPath(test.path)
+			k, err := test.key.DeriveChildFromPath(test.path)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expPriv, k.String())
 			pubKey, err := k.Neuter()

--- a/bip32/derivationpaths_test.go
+++ b/bip32/derivationpaths_test.go
@@ -165,7 +165,7 @@ func Test_DeriveChildFromPath(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			k, err := test.key.DeriveChildFromPath(test.path)
+			k, err := test.key.DeriveKeyFromPath(test.path)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expPriv, k.String())
 			pubKey, err := k.Neuter()


### PR DESCRIPTION
Adding helper methods to generate new extendedKeys and compressed public keys from a parent extended key using a specified derivation path.

This will save a lot of code being required in consuming applications when it comes to creating nested extended keys from derivation paths.

```go
newKey, err := extendedKey.DeriveChildFromPath(test.path)

pubKeyBytes, err := extendedKey.DerivePublicKeyFromPath(test.path)
```